### PR TITLE
Support Options to useOnlyUTC in the mail header

### DIFF
--- a/headeremitter.js
+++ b/headeremitter.js
@@ -72,6 +72,9 @@ function clamp(value, min, max, def) {
  *   @param [options.useASCII=true] {Boolean}
  *     If true, then RFC 2047 and RFC 2231 encoding of headers will be performed
  *     as needed to retain headers as ASCII.
+ *   @param [options.useOnlyUTC=true] {Boolean}
+ *     If true, then date added in header is always in UTC. This is to provide 
+ *     user location privacy by not revealing Timezone location.
  */
 function HeaderEmitter(handler, options) {
   /// The inferred value of options.useASCII


### PR DESCRIPTION
This PR supports all changes needed to support useOnlyUTC option in jsmime Header. This way, we can now customize jsmime to only use UTC as its TimeZone in the mail header so that the user's location through the TimeZone info is not leaked through the mail header.
